### PR TITLE
Update ft_max.c

### DIFF
--- a/day09/ex17/ft_max.c
+++ b/day09/ex17/ft_max.c
@@ -16,9 +16,9 @@ int		ft_max(int *tab, int length)
 	int		max;
 
 	i = -1;
-	max = 0;
+	max = tab[0];
 	while (++i < length)
-		if (max > tab[i])
+		if (max < tab[i])
 			max = tab[i];
 	return (max);
 }


### PR DESCRIPTION
Was returning the min instead of max.
Initialize the initial value of max to the first element of the array so that if only 1 el is in the array, it gets returned. Currently if only 1 el and is negative, wrong output.